### PR TITLE
Improve `PeriodicTask`'s old numeric handling

### DIFF
--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -647,6 +647,7 @@ class Conf(ConfigType):
         "json.bone.structure.camelcasenames",  # use camelCase attribute names (see #637 for details)
         "json.bone.structure.keytuples",  # use classic structure notation: `"structure = [["key", {...}] ...]` (#649)
         "json.bone.structure.inlists",  # dump skeleton structure with every JSON list response (#774 for details)
+        "tasks.periodic.useminutes",  # Use minutes instead of second for int/float value (#1133 for details)
     ]
     """Backward compatibility flags; Remove to enforce new layout."""
 

--- a/src/viur/core/config.py
+++ b/src/viur/core/config.py
@@ -647,7 +647,8 @@ class Conf(ConfigType):
         "json.bone.structure.camelcasenames",  # use camelCase attribute names (see #637 for details)
         "json.bone.structure.keytuples",  # use classic structure notation: `"structure = [["key", {...}] ...]` (#649)
         "json.bone.structure.inlists",  # dump skeleton structure with every JSON list response (#774 for details)
-        "tasks.periodic.useminutes",  # Use minutes instead of second for int/float value (#1133 for details)
+        "tasks.periodic.useminutes",  # Interpret int/float values for @PeriodicTask as minutes
+        #                               instead of seconds (#1133 for details)
     ]
     """Backward compatibility flags; Remove to enforce new layout."""
 


### PR DESCRIPTION
* float values were possible to
* Use `nonlocal` instead if `locals()`
* Add compatibility mode for the conversion